### PR TITLE
debug-response-observer (honey-3):

### DIFF
--- a/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/autoconfig/BeelineAutoconfig.java
+++ b/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/autoconfig/BeelineAutoconfig.java
@@ -113,7 +113,7 @@ public class BeelineAutoconfig implements WebMvcConfigurer {
     }
 
     @Bean
-    @ConditionalOnProperty(name = "honeycomb.beeline.log-honeycomb-responses")
+    @ConditionalOnProperty(name = "honeycomb.beeline.log-honeycomb-responses", matchIfMissing = true)
     @ConditionalOnMissingBean
     public ResponseObserver defaultBeelineResponseObserver() {
         return new DebugResponseObserver();

--- a/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/beans/CautiousResponseObserver.java
+++ b/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/beans/CautiousResponseObserver.java
@@ -1,0 +1,18 @@
+package io.honeycomb.beeline.spring.beans;
+
+import io.honeycomb.libhoney.responses.ServerRejected;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+
+/**
+ * A Response Observer that LOGs an ERROR if a 401 occurred, and otherwise logs at DEBUG or TRACE level.
+ */
+public class CautiousResponseObserver extends DebugResponseObserver {
+    private static final Logger LOG = LoggerFactory.getLogger(CautiousResponseObserver.class);
+
+    @Override
+    protected void handle401(ServerRejected serverRejected) {
+        LOG.error(ERROR_TEMPLATE_401, serverRejected);
+    }
+}

--- a/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/beans/DebugResponseObserver.java
+++ b/beeline-spring-boot-starter/src/main/java/io/honeycomb/beeline/spring/beans/DebugResponseObserver.java
@@ -7,9 +7,14 @@ import io.honeycomb.libhoney.responses.ServerRejected;
 import io.honeycomb.libhoney.responses.Unknown;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 
 public class DebugResponseObserver implements ResponseObserver {
     private static final Logger LOG = LoggerFactory.getLogger(DebugResponseObserver.class);
+
+    protected static final String ERROR_TEMPLATE_401 = "Server responded with a 401 HTTP error code to a batch request." +
+        " This is likely caused by using an incorrect 'Team Write Key'. Check https://ui.honeycomb.io/account to verify your " +
+        "team write key. Rejected event: {}";
 
     @Override
     public void onServerAccepted(final ServerAccepted serverAccepted) {
@@ -18,7 +23,11 @@ public class DebugResponseObserver implements ResponseObserver {
 
     @Override
     public void onServerRejected(final ServerRejected serverRejected) {
-        LOG.debug("Event rejected by Honeycomb server: {}", serverRejected);
+        if (serverRejected.getBatchData().getBatchStatusCode() == HttpStatus.UNAUTHORIZED.value()) {
+            handle401(serverRejected);
+        } else {
+            LOG.debug("Event rejected by Honeycomb server: {}", serverRejected);
+        }
     }
 
     @Override
@@ -29,5 +38,9 @@ public class DebugResponseObserver implements ResponseObserver {
     @Override
     public void onUnknown(final Unknown unknown) {
         LOG.debug("Received an unknown error while trying to send Event to Honeycomb: {}", unknown);
+    }
+
+    protected void handle401(final ServerRejected serverRejected) {
+        LOG.debug(ERROR_TEMPLATE_401, serverRejected);
     }
 }

--- a/beeline-spring-boot-starter/src/test/java/io/honeycomb/beeline/spring/autoconfig/BeelineAutoconfigTest.java
+++ b/beeline-spring-boot-starter/src/test/java/io/honeycomb/beeline/spring/autoconfig/BeelineAutoconfigTest.java
@@ -226,7 +226,7 @@ public class BeelineAutoconfigTest {
     }
 
     @Test
-    public void GIVEN_aNormalWebApplicationContext_EXPECT_RestTemplateInterceptorToNotBeLoaded() {
+    public void GIVEN_restTemplateIsDisabled_EXPECT_RestTemplateInterceptorToNotBeLoaded() {
         webApplicationContextRunner
             .withConfiguration(AutoConfigurations.of(BeelineAutoconfig.class))
             .withPropertyValues(defaultProps)
@@ -239,15 +239,27 @@ public class BeelineAutoconfigTest {
     }
 
     @Test
-    public void GIVEN_aNormalWebApplicationContext_EXPECT_NoResponseObserverToBeLoaded() {
+    public void GIVEN_aNormalWebApplicationContext_EXPECT_DebugResponseObserverToBeLoaded() {
         webApplicationContextRunner
             .withConfiguration(AutoConfigurations.of(BeelineAutoconfig.class))
             .withPropertyValues(defaultProps)
+            .run(context -> {
+                assertThat(context).hasSingleBean(ResponseObserver.class);
+                assertThat(context).hasSingleBean(DebugResponseObserver.class);
+            });
+    }
 
+    @Test
+    public void GIVEN_defaultResponseObserverIsDisabled_EXPECT_DebugResponseObserverToNotBeLoaded() {
+        webApplicationContextRunner
+            .withConfiguration(AutoConfigurations.of(BeelineAutoconfig.class))
+            .withPropertyValues(defaultProps)
+            .withPropertyValues("honeycomb.beeline.log-honeycomb-responses=false")
             .run(context -> {
                 assertThat(context).doesNotHaveBean(ResponseObserver.class);
             });
     }
+
 
     @Configuration
     public static class ResponseObserverConfig {
@@ -263,7 +275,10 @@ public class BeelineAutoconfigTest {
             .withConfiguration(AutoConfigurations.of(BeelineAutoconfig.class))
             .withUserConfiguration(ResponseObserverConfig.class)
             .withPropertyValues(defaultProps)
-            .run(context -> assertThat(context).hasSingleBean(ResponseObserver.class));
+            .run(context -> {
+                assertThat(context).hasSingleBean(ResponseObserver.class);
+                assertThat(context).doesNotHaveBean(DebugResponseObserver.class);
+            });
     }
 
 

--- a/beeline-spring-boot-starter/src/test/resources/application-path-pattern-test.properties
+++ b/beeline-spring-boot-starter/src/test/resources/application-path-pattern-test.properties
@@ -2,6 +2,6 @@ honeycomb.beeline.dataset     :testDataset
 honeycomb.beeline.write-key   :testWriteKey
 honeycomb.beeline.api-host    :http://localhost:8089
 honeycomb.beeline.service-name:IntegrationTestApp
-
 honeycomb.beeline.include-path-patterns: /whitelist/**
 honeycomb.beeline.exclude-path-patterns: /blacklist/**
+honeycomb.beeline.log-honeycomb-responses: false

--- a/beeline-spring-boot-starter/src/test/resources/application-request-test.properties
+++ b/beeline-spring-boot-starter/src/test/resources/application-request-test.properties
@@ -2,4 +2,4 @@ honeycomb.beeline.dataset     :testDataset
 honeycomb.beeline.write-key   :testWriteKey
 honeycomb.beeline.api-host    :http://localhost:8089
 honeycomb.beeline.service-name:IntegrationTestApp
-#debug:true
+honeycomb.beeline.log-honeycomb-responses: false


### PR DESCRIPTION
- debug response observer is added unless explicitly disabled. Test using configuration tests.
- test profiles disable the observer as existing test configuration means that the mocks are invoked at Spring configuration time if observer is present.
- add a version of the reponse observer which logs 401s at ERROR level. This is not used by default.