### PR TITLE
Simplified Builder for Beeline (#43)

### DIFF
--- a/beeline-core/pom.xml
+++ b/beeline-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.honeycomb.beeline</groupId>
         <artifactId>beeline-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
     <name>Beeline Java (Core)</name>
     <artifactId>beeline-core</artifactId>
@@ -31,6 +31,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <doclint>none</doclint>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/beeline-core/src/main/java/io/honeycomb/beeline/builder/BeelineBuilder.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/builder/BeelineBuilder.java
@@ -1,0 +1,472 @@
+package io.honeycomb.beeline.builder;
+
+import io.honeycomb.beeline.tracing.Beeline;
+import io.honeycomb.beeline.tracing.SpanBuilderFactory;
+import io.honeycomb.beeline.tracing.SpanPostProcessor;
+import io.honeycomb.beeline.tracing.Tracer;
+import io.honeycomb.beeline.tracing.Tracing;
+import io.honeycomb.beeline.tracing.sampling.Sampling;
+import io.honeycomb.beeline.tracing.sampling.TraceSampler;
+import io.honeycomb.libhoney.Event;
+import io.honeycomb.libhoney.EventFactory;
+import io.honeycomb.libhoney.EventPostProcessor;
+import io.honeycomb.libhoney.HoneyClient;
+import io.honeycomb.libhoney.LibHoney;
+import io.honeycomb.libhoney.ResponseObserver;
+import io.honeycomb.libhoney.ValueSupplier;
+import io.honeycomb.libhoney.builders.HoneyClientBuilder;
+import io.honeycomb.libhoney.responses.ClientRejected.RejectionReason;
+import io.honeycomb.libhoney.transport.Transport;
+import io.honeycomb.libhoney.transport.batch.impl.HoneycombBatchConsumer;
+
+import javax.net.ssl.SSLContext;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class BeelineBuilder {
+    protected HoneyClientBuilder clientBuilder = new HoneyClientBuilder();
+    private SpanBuilderFactory defaultFactory = null;
+    private Integer sampleRate = null;
+    private SpanPostProcessor spanPostProcessor = null;
+    private Tracer tracer = null;
+
+
+    /**
+     * Build new Beeline instance as configured by calling the various builder methods previous to this call.
+     * <p>
+     * <h3>Example</h3>
+     * <pre>{@code
+     * Beeline beeline = new BeelineBuilder()
+     *                          .dataSet("dataset")
+     *                          .writeKey("write key")
+     *                          .addProxy("proxy.domain.com")
+     *                          .build()}</pre>
+     *
+     * @return new Beeline instance
+     */
+    public Beeline build() {
+        final HoneyClient client = clientBuilder.build();
+        return createBeeline(client);
+    }
+
+
+    @SuppressWarnings("unchecked")
+    private Beeline createBeeline(final HoneyClient client) {
+        final TraceSampler<Object> sampler = (TraceSampler<Object>) selectSampler();
+        final SpanPostProcessor postProcessor = spanPostProcessor != null ? spanPostProcessor : Tracing.createSpanProcessor(client, sampler);
+        final SpanBuilderFactory factory = defaultFactory != null ? defaultFactory : Tracing.createSpanBuilderFactory(postProcessor, sampler);
+        final Tracer tracer = this.tracer != null ? this.tracer : Tracing.createTracer(factory);
+        return Tracing.createBeeline(tracer, factory);
+    }
+
+    private TraceSampler<?> selectSampler() {
+        if (sampleRate == null) {
+            return Sampling.alwaysSampler();
+        }
+        if (sampleRate == 0) {
+            return Sampling.neverSampler();
+        }
+        return Sampling.deterministicSampler(sampleRate);
+    }
+
+    /**
+     * Use this to add fields to all events, where both keys and values are fixed.
+     * Entries may be overridden before the event is sent to the server. See "Usage" on {@link HoneyClient}'s
+     * class documentation.
+     * <p>
+     * Default: None
+     *
+     * @param name  the "key".
+     * @param field the "value"
+     * @return this.
+     * @see io.honeycomb.libhoney.Options.Builder#setGlobalFields(java.util.Map)
+     */
+    public BeelineBuilder addGlobalField(final String name, final Object field) {
+        clientBuilder.addGlobalField(name, field);
+        return this;
+    }
+
+    /**
+     * Use this method to supply fields to events, where keys are fixed but values are dynamically created at runtime.
+     * Entries may be overridden before the event is sent to the server. See "Usage" on {@link HoneyClient}'s
+     * class documentation.
+     * <p>
+     * Default: None
+     *
+     * @param name          the "key"
+     * @param valueSupplier calculates value
+     * @see io.honeycomb.libhoney.Options.Builder#setGlobalDynamicFields(java.util.Map)
+     */
+    public BeelineBuilder addGlobalDynamicFields(final String name, final ValueSupplier<?> valueSupplier) {
+        clientBuilder.addGlobalDynamicFields(name, valueSupplier);
+        return this;
+    }
+
+    /**
+     * Use this method to configure the HTTP client to use a proxy that needs authentication.
+     * <p>
+     * For configuring a proxy server without authentication see: {@link #addProxy(String)}
+     *
+     * @param proxyHost hostname of the proxy, frequently FQDN of the server
+     * @param username  username for authentication with proxy server
+     * @param password  password for authentication with proxy server
+     */
+    public BeelineBuilder addProxy(final String proxyHost, final String username, final String password) {
+        clientBuilder.addProxy(proxyHost, username, password);
+        return this;
+    }
+
+    /**
+     * Dataset is the name of the Honeycomb dataset to which to send these events.
+     * If it is specified during {@link LibHoney} initialization, it will be used as the default dataset for all
+     * events. If absent, dataset must be explicitly set on an {@link EventFactory} or {@link Event}.
+     *
+     * @param dataSet to set.
+     * @see io.honeycomb.libhoney.Options.Builder#setDataset(java.lang.String)
+     * <p>
+     * Default: None
+     */
+    public BeelineBuilder dataSet(final String dataSet) {
+        clientBuilder.dataSet(dataSet);
+        return this;
+    }
+
+    /**
+     * APIHost is the hostname for the Honeycomb API server to which to send this event.
+     * <p>
+     * Default: {@code https://api.honeycomb.io/}
+     *
+     * @param apiHost to set.
+     * @see io.honeycomb.libhoney.Options.Builder#setApiHost(java.net.URI)
+     */
+    public BeelineBuilder apiHost(final String apiHost) throws URISyntaxException {
+        clientBuilder.apiHost(apiHost);
+        return this;
+    }
+
+    /**
+     * WriteKey is the Honeycomb authentication token.
+     * If it is specified during {@link LibHoney} initialization, it will be used as the default write key for all
+     * events.
+     * If absent, write key must be explicitly set on a builder or event.
+     * Find your team write key at https://ui.honeycomb.io/account
+     * <p>
+     * Default: None
+     *
+     * @param writeKey to set.
+     * @see io.honeycomb.libhoney.Options.Builder#setWriteKey(java.lang.String)
+     */
+    public BeelineBuilder writeKey(final String writeKey) {
+        clientBuilder.writeKey(writeKey);
+        return this;
+    }
+
+    /**
+     * Setting Debug to true will ensure the DefaultDebugResponseObserver to the HoneyClient's list of response observers.
+     * Default: false
+     *
+     * @param enabled true to enable debug response observer
+     */
+    public BeelineBuilder debug(final boolean enabled) {
+        clientBuilder.debug(enabled);
+        return this;
+    }
+
+    /**
+     * SampleRate is the rate at which to sample this event. Default is 1, meaning no sampling.
+     * The probability of sending is {@code 1/sampleRate}. In other words, if one out of every 250 events is to be
+     * sent when Send() is called, you would specify set sample rate to 250.
+     * <p>
+     * Must be greater than 1<br>
+     * Default: 1
+     *
+     * @param sampleRate average number of events until sample is taken.
+     */
+    public BeelineBuilder sampleRate(final int sampleRate) {
+        this.sampleRate = sampleRate;
+        clientBuilder.sampleRate(sampleRate);
+        return this;
+    }
+
+    /**
+     * This determines that maximum number of events that get sent to the Honeycomb server (via a batch request).
+     * In other words, this is a trigger that will cause a batch request to be created if a batch reaches this
+     * maximum size.
+     * <p>
+     * Also see {@link io.honeycomb.libhoney.TransportOptions.Builder#setBatchTimeoutMillis}, as that might cause batch request to be created
+     * earlier (triggering on time rather than space).
+     * <p>
+     * Note: Events are grouped into batches that have the same write key, dataset name and API host.
+     * See {@link Event#setWriteKey(String)}, {@link Event#setDataset(String)}, and {@link Event#setApiHost(URI)}.
+     *
+     * @param batchSize max number of events to send in single data transmission
+     */
+    public BeelineBuilder batchSize(final int batchSize) {
+        clientBuilder.batchSize(batchSize);
+        return this;
+    }
+
+    /**
+     * If batches do no fill up to the batch size in time (as defined by {@link io.honeycomb.libhoney.TransportOptions.Builder#setBatchSize(int)}), then
+     * this timeout will trigger a batch request to the Honeycomb server. Essentially, for batches that fill
+     * slowly, this ensures that there is a temporal upper bound to when events are sent via a batch request.
+     * The time is measured in milliseconds.
+     * <p>
+     * Note: Events are grouped into batches that have the same write key, dataset name and API host.
+     * See {@link Event#setWriteKey(String)}, {@link Event#setDataset(String)}, and {@link Event#setApiHost(URI)}.
+     * <p>
+     * Default: 100
+     *
+     * @param batchTimeoutMillis max milliseconds to send non-empty but not-full batch.
+     */
+    public BeelineBuilder batchTimeoutMillis(final long batchTimeoutMillis) {
+        clientBuilder.batchTimeoutMillis(batchTimeoutMillis);
+        return this;
+    }
+
+    /**
+     * This sets the capacity of the queue that events are submitted to before they get processed for batching
+     * and eventually sent to the honeycomb HTTP endpoint.
+     * <p>
+     * Under normal circumstances this queue should remain near empty, but in case of heavy load it acts as a
+     * bounded buffer against a build up of backpressure from the batching and http client implementation.
+     * <p>
+     * Default: 10000
+     *
+     * @param queueCapacity queue size.
+     * @see RejectionReason#QUEUE_OVERFLOW
+     * @see io.honeycomb.libhoney.transport.batch.BatchConsumer#consume(java.util.List)
+     */
+    public BeelineBuilder queueCapacity(final int queueCapacity) {
+        clientBuilder.queueCapacity(queueCapacity);
+        return this;
+    }
+
+    /**
+     * This determines the maximum number of batch requests that can be still pending completion at any one time.
+     * Set to -1 if there is no maximum, i.e. the number of batch requests pending completion is allowed to grow
+     * without bound.
+     * <p>
+     * Once a batch request has been triggered (see {@link io.honeycomb.libhoney.TransportOptions.Builder#setBatchSize(int)} and
+     * {@link io.honeycomb.libhoney.TransportOptions.Builder#setBatchTimeoutMillis(long)}), then the batch request is submitted
+     * to {@link io.honeycomb.libhoney.transport.batch.BatchConsumer#consume(java.util.List)}.
+     * <p>
+     * If the maximum pending requests is reached, then
+     * {@link io.honeycomb.libhoney.transport.batch.BatchConsumer#consume(java.util.List)} may block until the number of
+     * pending requests has dropped below the threshold.
+     * <p>
+     * This allows backpressure to be created if the {@link io.honeycomb.libhoney.transport.batch.BatchConsumer}
+     * implementation cannot keep up with the number of batch requests being submitted. The intended consequence of
+     * this is that the event queue may reach its capacity and overflow.
+     * <p>
+     * See {@link io.honeycomb.libhoney.TransportOptions.Builder#setQueueCapacity(int)}.
+     * <p>
+     * This configuration differs from {@link io.honeycomb.libhoney.TransportOptions.Builder#getMaxConnections()} in that a batch request may be pending
+     * completion, but it may be still be waiting for an HTTP connection. This is the case in the default
+     * {@link HoneycombBatchConsumer} where the
+     * {@link org.apache.http.nio.client.HttpAsyncClient} maintains an internal unbounded pending queue for
+     * requests that are waiting for a connection. This configuration effectively puts a bound on the total
+     * number of batch requests being serviced by the HTTP client, regardless of whether they have
+     * a connection or not.
+     * <p>
+     * Default: 250
+     *
+     * @param maxPendingBatchRequests max simultaneous requests.
+     * @see io.honeycomb.libhoney.TransportOptions.Builder#setMaxConnections(int)
+     */
+    public BeelineBuilder maxPendingBatchRequests(final int maxPendingBatchRequests) {
+        clientBuilder.maxPendingBatchRequests(maxPendingBatchRequests);
+        return this;
+    }
+
+    /**
+     * Set this to define the maximum amount of connections the http client may hold in its connection pool.
+     * In effect this is the maximum level of concurrent HTTP requests that may be in progress at any given time.
+     * <p>
+     * Default: 200
+     *
+     * @param maxConnections maximum number of connections.
+     * @see org.apache.http.impl.nio.client.HttpAsyncClientBuilder#setMaxConnTotal(int)
+     */
+    public BeelineBuilder maxConnections(final int maxConnections) {
+        clientBuilder.maxConnections(maxConnections);
+        return this;
+    }
+
+    /**
+     * Set this to define the maximum amount of connections the http client may hold in its connection pool for a
+     * given hostname.
+     * In effect this limits how many concurrent requests may be sent to a single host.
+     * <p>
+     * Default: 100
+     *
+     * @param maxConnectionsPerApiHost pool size for per hostname
+     * @see org.apache.http.impl.nio.client.HttpAsyncClientBuilder#setMaxConnPerRoute(int)
+     */
+    public BeelineBuilder maxConnectionsPerApiHost(final int maxConnectionsPerApiHost) {
+        clientBuilder.maxConnectionsPerApiHost(maxConnectionsPerApiHost);
+        return this;
+    }
+
+    /**
+     * Set this to define the http client's connect timeout in milliseconds. Set to 0 for no timeout.
+     * <p>
+     * Default: 0
+     *
+     * @param connectTimeout to set.
+     * @see org.apache.http.client.config.RequestConfig#getConnectTimeout()
+     */
+    public BeelineBuilder connectionTimeout(final int connectTimeout) {
+        clientBuilder.connectionTimeout(connectTimeout);
+        return this;
+    }
+
+    /**
+     * Set this to define the http client's connection request timeout in milliseconds. This defines the maximum
+     * time that a batch request can wait for a connection from the connection manager after
+     * submission to the HTTP client. Set to 0 for no timeout.
+     * <p>
+     * Beware that setting this to a non-zero value might conflict with the backpressure effect of the
+     * {@link io.honeycomb.libhoney.transport.batch.BatchConsumer} implementation, and so might see an increase
+     * in failed batches. See {@link #maxPendingBatchRequests(int)} for more detail.
+     * <p>
+     * Default: 0
+     *
+     * @param connectionRequestTimeout to set.
+     * @see org.apache.http.client.config.RequestConfig#getConnectionRequestTimeout()
+     */
+    public BeelineBuilder connectionRequestTimeout(final int connectionRequestTimeout) {
+        clientBuilder.connectionRequestTimeout(connectionRequestTimeout);
+        return this;
+    }
+
+    /**
+     * Set this to define the http client's socket timeout in milliseconds. Set to 0 for no timeout.
+     * <p>
+     * Default: 3000
+     *
+     * @param socketTimeout to set.
+     * @see org.apache.http.client.config.RequestConfig#getSocketTimeout()
+     */
+    public BeelineBuilder socketTimeout(final int socketTimeout) {
+        clientBuilder.socketTimeout(socketTimeout);
+        return this;
+    }
+
+    /**
+     * Set this to define the http client's socket buffer size in bytes.
+     * <p>
+     * Default: 8192
+     *
+     * @param bufferSize to set.
+     * @see org.apache.http.config.ConnectionConfig.Builder#setBufferSize(int)
+     */
+    public BeelineBuilder bufferSize(final int bufferSize) {
+        clientBuilder.bufferSize(bufferSize);
+        return this;
+    }
+
+    /**
+     * Set this to define the http client's io thread count. This is usually set to the number of CPU cores.
+     * <p>
+     * Default: System CPU cores.
+     *
+     * @param ioThreadCount to set, must be between 1 and the system's number of CPU cores.
+     * @see <a href="https://hc.apache.org/httpcomponents-core-ga/tutorial/html/nio.html">Apache http client NIO</a>
+     * @see org.apache.http.impl.nio.reactor.IOReactorConfig#getIoThreadCount()
+     */
+    public BeelineBuilder ioThreadCount(final int ioThreadCount) {
+        clientBuilder.ioThreadCount(ioThreadCount);
+        return this;
+    }
+
+    /**
+     * Defines the maximum time (in milliseconds) that we should wait for any pending HTTP requests to complete
+     * during the client shutdown process.
+     * <p>
+     * Any requests that are still pending at the end of this wait period will be terminated.
+     * <p>
+     * Default: 2000
+     *
+     * @param maximumHttpRequestShutdownWait milliseconds.
+     * @see io.honeycomb.libhoney.TransportOptions.Builder#setMaximumHttpRequestShutdownWait(long)
+     */
+    public BeelineBuilder maximumHttpRequestShutdownWait(final Long maximumHttpRequestShutdownWait) {
+        clientBuilder.maximumHttpRequestShutdownWait(maximumHttpRequestShutdownWait);
+        return this;
+    }
+
+    /**
+     * Set this to add an additional component to the user agent header sent to Honeycomb when Events are submitted.
+     * This is usually only of interest for instrumentation libraries that wrap LibHoney.
+     * <p>
+     * Default: None
+     *
+     * @param additionalUserAgent added to the user agent on http request header.
+     * @see io.honeycomb.libhoney.TransportOptions.Builder#setAdditionalUserAgent(java.lang.String)
+     */
+    public BeelineBuilder additionalUserAgent(final String additionalUserAgent) {
+        clientBuilder.additionalUserAgent(additionalUserAgent);
+        return this;
+    }
+
+    /**
+     * Use this method to configure the HTTP client to use a proxy without authentication.
+     * <p>
+     * For configuring a proxy server with authentication see: {@link #addProxy(String, String, String)}
+     *
+     * @param host hostname of the proxy, frequently FQDN of the server
+     */
+    public BeelineBuilder addProxy(final String host) {
+        clientBuilder.addProxy(host);
+        return this;
+    }
+
+    public BeelineBuilder sslContext(final SSLContext sslContext) {
+        clientBuilder.sslContext(sslContext);
+        return this;
+    }
+
+    public BeelineBuilder spanPostProcessor(final SpanPostProcessor spanPostProcessor) {
+        this.spanPostProcessor = spanPostProcessor;
+        return this;
+    }
+
+    public BeelineBuilder spanBuilderFactory(final SpanBuilderFactory factory) {
+        this.defaultFactory = factory;
+        return this;
+    }
+
+    public BeelineBuilder tracer(final Tracer tracer) {
+        this.tracer = tracer;
+        return this;
+    }
+
+    public BeelineBuilder addResponseObserver(final ResponseObserver responseObserver) {
+        clientBuilder.addResponseObserver(responseObserver);
+        return this;
+    }
+
+    /**
+     * Set this to apply post processing to any event about to be submitted to Honeycomb.
+     * See {@link EventPostProcessor} for details.
+     * <p>
+     * Default: None
+     *
+     * @param eventPostProcessor to set.
+     */
+    public BeelineBuilder eventPostProcessor(final EventPostProcessor eventPostProcessor) {
+        clientBuilder.eventPostProcessor(eventPostProcessor);
+        return this;
+    }
+
+    /**
+     * Transport for sending events to HoneyComb. Used by the {@link io.honeycomb.libhoney.HoneyClient} internals.
+     * This can also be used to disable sending events to Honeycomb by passing in a mock Transport.
+     */
+    public BeelineBuilder transport(final Transport transport){
+       clientBuilder.transport(transport);
+       return this;
+    }
+
+}

--- a/beeline-core/src/main/java/io/honeycomb/beeline/builder/README.md
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/builder/README.md
@@ -1,0 +1,66 @@
+# Building Beelines with the BeelineBuilder
+BeelineBuilder is a unified API for Beelines to simplify user configuration between the Beeline and the HoneyClient.
+
+## Directly building Beelines
+BeelineBuilder follows the Builder pattern. So create an instance of the builder, configure the options you need, and then call `build()`.
+
+```java
+package com.example.MyApp;
+
+import io.honeycomb.beeline.DefaultBeeline;
+import io.honeycomb.beeline.builder.BeelineBuilder;
+import io.honeycomb.beeline.tracing.Beeline;
+
+public class MyApp{
+    /// ...
+    public static void main( final String[] args ) {
+        final BeelineBuilder builder = new BeelineBuilder();
+        // Configure builder
+        builder.dataSet("test-dataset").writeKey("WRITE_KEY");
+        // Build beeline
+        final Beeline beeline = builder.build();
+
+        // ...
+
+        // Call close at program termination to ensure all pending
+        // spans are sent.
+        beeline.close();
+    }
+}
+```
+
+## Using DefaultBeeline
+DefaultBeeline has a `getInstance` method which takes BeelineBuilder and serviceName.
+
+```java
+package com.example.MyApp;
+
+import io.honeycomb.beeline.DefaultBeeline;
+import io.honeycomb.beeline.builder.BeelineBuilder;
+
+public class MyApp{
+    /// ...
+    public static void main( final String[] args ) {
+        final BeelineBuilder builder = new BeelineBuilder();
+        builder.dataSet("test-dataset").writeKey("WRITE_KEY");
+        final DefaultBeeline beeline = DefaultBeeline.getInstance(builder, "my-app");
+
+        // ...
+
+        // Call close at program termination to ensure all pending
+        // spans are sent.
+        beeline.close();
+    }
+}
+```
+
+## Simplified Proxy Configuration
+Some applications need to configure outgoing requests through a proxy server. To add a proxy server that does not need authentication, simply point to the proxy service.
+```java
+builder.addProxy("https://myproxy.example.com");
+```
+
+If your proxy server needs authentication, you will need to pass in credentials. Note: this example retrieves the password from an environment variable, but this could easily come from system properties or properties/configuration file instead.
+```java
+builder.addProxy("https://myproxy.example.com", "user", System.getenv("proxy_password"));
+```

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Beeline.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/Beeline.java
@@ -195,4 +195,16 @@ public class Beeline {
     public SpanBuilderFactory getSpanBuilderFactory() {
         return factory;
     }
+
+    /**
+     * <p>Close the Beeline by closing SpanBuilderFactory which will internally close the HoneyClient instance.</p>
+     * <p>This method should be called in lieu of {@code HoneyClient.close()}. Only one close method needs to be called.
+     * {@code beeline.close()} OR {@code honeyClient.close()}</p>
+     * <p>This will send any pending events.</p>
+     * @see io.honeycomb.libhoney.HoneyClient#close()
+     */
+    public void close(){
+        factory.close();
+    }
 }
+

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/SpanBuilderFactory.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/SpanBuilderFactory.java
@@ -130,6 +130,13 @@ public class SpanBuilderFactory {
     }
 
     /**
+     * Close the SpanPostProcessor. This will essentially close the HoneyClient after sending any pending events.
+     */
+    public void close() {
+        processor.close();
+    }
+
+    /**
      * Builder to capture various attributes to initialise a Span with.
      * <p>
      * Some properties are already initialised to defaults, but you may have to provide spanName and serviceName.

--- a/beeline-core/src/main/java/io/honeycomb/beeline/tracing/SpanPostProcessor.java
+++ b/beeline-core/src/main/java/io/honeycomb/beeline/tracing/SpanPostProcessor.java
@@ -63,4 +63,11 @@ public class SpanPostProcessor {
             .addField(TraceFieldConstants.DURATION_FIELD, span.elapsedTimeMs());
         return event;
     }
+
+    /**
+     * Close the HoneyClient instance. This will send any pending events.
+     */
+    public void close() {
+        client.close();
+    }
 }

--- a/beeline-core/src/test/java/io/honeycomb/beeline/builder/BeelineBuilderTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/builder/BeelineBuilderTest.java
@@ -1,0 +1,236 @@
+package io.honeycomb.beeline.builder;
+
+import io.honeycomb.beeline.tracing.Beeline;
+import io.honeycomb.libhoney.EventPostProcessor;
+import io.honeycomb.libhoney.ResponseObserver;
+import io.honeycomb.libhoney.ValueSupplier;
+import io.honeycomb.libhoney.builders.HoneyClientBuilder;
+import io.honeycomb.libhoney.transport.Transport;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import javax.net.ssl.SSLContext;
+
+import java.net.URISyntaxException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BeelineBuilderTest {
+
+    BeelineBuilder builder;
+    HoneyClientBuilder mockBuilder;
+    @Before
+    public void setUp() {
+        builder = new BeelineBuilder();
+        builder.clientBuilder = mockBuilder = spy(builder.clientBuilder);
+        when(mockBuilder.build()).thenCallRealMethod();
+    }
+
+    @Test
+    public void addGlobalField() {
+        final Beeline beeline = builder.addGlobalField("name", "value").build();
+        verify(mockBuilder, times(1)).addGlobalField("name", "value");
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void addGlobalDynamicFields() {
+        final Beeline beeline = builder.addGlobalDynamicFields("name", mock(ValueSupplier.class)).build();
+        verify(mockBuilder, times(1)).addGlobalDynamicFields(eq("name"), any(ValueSupplier.class));
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void addProxyCredential() {
+        final Beeline beeline = builder.addProxy("proxy.domain.com:8443", "user", "secret").build();
+        verify(mockBuilder, times(1)).addProxy("proxy.domain.com:8443", "user", "secret");
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void dataSet() {
+        final Beeline beeline = builder.dataSet("set").build();
+        verify(mockBuilder, times(1)).dataSet("set");
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void apiHost() throws URISyntaxException {
+        final Beeline beeline = builder.apiHost("host:80").build();
+        verify(mockBuilder, times(1)).apiHost("host:80");
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void writeKey() {
+        final Beeline beeline = builder.writeKey("key").build();
+        verify(mockBuilder, times(1)).writeKey("key");
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void testDebugEnabled() {
+        final Beeline beeline = builder.debug(true).build();
+        verify(mockBuilder, times(1)).debug(true);
+        completeNegativeVerification();
+    }
+    @Test
+    public void testDebugDisabled() {
+        final Beeline beeline = builder.debug(false).build();
+        verify(mockBuilder, times(1)).debug(false);
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void sampleRate() {
+        final Beeline beeline = builder.sampleRate(123).build();
+        verify(mockBuilder, times(1)).sampleRate(123);
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void batchSize() {
+        final Beeline beeline = builder.batchSize(123).build();
+        verify(mockBuilder, times(1)).batchSize(123);
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void batchTimeoutMillis() {
+        final Beeline beeline = builder.batchTimeoutMillis(123).build();
+        verify(mockBuilder, times(1)).batchTimeoutMillis(123);
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void queueCapacity() {
+        builder.queueCapacity(123).build();
+        verify(mockBuilder, times(1)).queueCapacity(123);
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void maxPendingBatchRequests() {
+        builder.maxPendingBatchRequests(123).build();
+        verify(mockBuilder, times(1)).maxPendingBatchRequests(123);
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void maxConnections() {
+        builder.maxConnections(123).build();
+        verify(mockBuilder, times(1)).maxConnections(123);
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void maxConnectionsPerApiHost() {
+        builder.maxConnectionsPerApiHost(123).build();
+        verify(mockBuilder, times(1)).maxConnectionsPerApiHost(123);
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void connectionTimeout() {
+        final Beeline beeline = builder.connectionTimeout(123).build();
+        verify(mockBuilder, times(1)).connectionTimeout(123);
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void connectionRequestTimeout() {
+        builder.connectionRequestTimeout(123).build();
+        verify(mockBuilder, times(1)).connectionRequestTimeout(123);
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void socketTimeout() {
+        builder.socketTimeout(123).build();
+        verify(mockBuilder, times(1)).socketTimeout(123);
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void bufferSize() {
+        builder.bufferSize(5_000).build();
+        verify(mockBuilder, times(1)).bufferSize(5_000);
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void ioThreadCount() {
+        builder.ioThreadCount(1).build();
+        verify(mockBuilder, times(1)).ioThreadCount(1);
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void maximumHttpRequestShutdownWait() {
+        builder.maximumHttpRequestShutdownWait(345L).build();
+        verify(mockBuilder, times(1)).maximumHttpRequestShutdownWait(345L);
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void additionalUserAgent() {
+        builder.additionalUserAgent("agent").build();
+        verify(mockBuilder, times(1)).additionalUserAgent("agent");
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void addProxyNoCredentials() {
+        builder.addProxy("proxyHost").build();
+        verify(mockBuilder, times(1)).addProxy(anyString());
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void sslContext() {
+        final SSLContext mockContext = mock(SSLContext.class);
+        builder.sslContext(mockContext).build();
+        verify(mockBuilder, times(1)).sslContext(any(SSLContext.class));
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void addResponseObserver() {
+        builder.addResponseObserver(mock(ResponseObserver.class)).build();
+        verify(mockBuilder, times(1)).addResponseObserver(any(ResponseObserver.class));
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void eventPostProcessor() {
+        builder.eventPostProcessor(mock(EventPostProcessor.class)).build();
+        verify(mockBuilder, times(1)).eventPostProcessor(any(EventPostProcessor.class));
+        completeNegativeVerification();
+    }
+
+    @Test
+    public void transport() {
+        final Transport mockTransport = mock(Transport.class);
+        final Beeline beeline = builder.transport(mockTransport).build();
+
+        verify(mockBuilder, times(1)).transport(mockTransport);
+        verifyNoMoreInteractions(mockTransport);
+        completeNegativeVerification();
+    }
+
+    private void completeNegativeVerification(){
+        verify(mockBuilder, times(1)).build();
+        verifyNoMoreInteractions(mockBuilder);
+    }
+}

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/BeelineTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/BeelineTest.java
@@ -1,9 +1,14 @@
 package io.honeycomb.beeline.tracing;
 
+import io.honeycomb.beeline.builder.BeelineBuilder;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 
 public class BeelineTest {
 
@@ -11,8 +16,7 @@ public class BeelineTest {
     public void GIVEN_aBeelineConstructedWithArguments_EXPECT_gettersToReturnSameArguments() {
         final SpanBuilderFactory factory = mock(SpanBuilderFactory.class);
         final Tracer tracer = mock(Tracer.class);
-
-        final Beeline beeline = new Beeline(tracer, factory);
+        final Beeline beeline = new BeelineBuilder().tracer(tracer).spanBuilderFactory(factory).build();
 
         assertThat(beeline.getTracer()).isEqualTo(tracer);
         assertThat(beeline.getSpanBuilderFactory()).isEqualTo(factory);
@@ -23,7 +27,7 @@ public class BeelineTest {
     public void GIVEN_beeline_WHEN_gettingActiveSpan_EXPECT_beelineToDelegateToTracer() {
         final SpanBuilderFactory factory = mock(SpanBuilderFactory.class);
         final Tracer tracer = mock(Tracer.class);
-        final Beeline beeline = new Beeline(tracer, factory);
+        final Beeline beeline = new BeelineBuilder().tracer(tracer).spanBuilderFactory(factory).build();
 
         beeline.getActiveSpan();
 
@@ -35,7 +39,7 @@ public class BeelineTest {
     public void GIVEN_beeline_WHEN_startingChild_EXPECT_beelineToDelegateToTracer() {
         final SpanBuilderFactory factory = mock(SpanBuilderFactory.class);
         final Tracer tracer = mock(Tracer.class);
-        final Beeline beeline = new Beeline(tracer, factory);
+        final Beeline beeline = new BeelineBuilder().tracer(tracer).spanBuilderFactory(factory).build();
 
         beeline.startChildSpan("child");
 
@@ -49,7 +53,7 @@ public class BeelineTest {
         final Tracer tracer = mock(Tracer.class);
         final TracerSpan mockSpan = mock(TracerSpan.class);
         when(tracer.getActiveSpan()).thenReturn(mockSpan);
-        final Beeline beeline = new Beeline(tracer, factory);
+        final Beeline beeline = new BeelineBuilder().tracer(tracer).spanBuilderFactory(factory).build();
 
         beeline.addField("key", "value");
 
@@ -64,12 +68,24 @@ public class BeelineTest {
         final Tracer tracer = mock(Tracer.class);
         final TracerSpan mockSpan = mock(TracerSpan.class);
         when(tracer.getActiveSpan()).thenReturn(mockSpan);
-        final Beeline beeline = new Beeline(tracer, factory);
+        final Beeline beeline = new BeelineBuilder().tracer(tracer).spanBuilderFactory(factory).build();
 
         beeline.addField("app.key", "value");
 
         verify(tracer).getActiveSpan();
         verify(mockSpan).addField("app.key", "value");
         verifyNoMoreInteractions(tracer, factory, mockSpan);
+    }
+
+    @Test
+    public void GIVEN_beeline_WHEN_closing_EXPECT_beelineToDelegateToSpanBuilderFactory() {
+        final SpanBuilderFactory factory = mock(SpanBuilderFactory.class);
+        final Tracer tracer = mock(Tracer.class);
+        final Beeline beeline = new Beeline(tracer, factory);
+
+        beeline.close();
+
+        verify(factory).close();
+        verifyNoMoreInteractions(tracer, factory);
     }
 }

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/SpanBuilderFactoryTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/SpanBuilderFactoryTest.java
@@ -14,6 +14,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class SpanBuilderFactoryTest {
     private SpanBuilderFactory factory = new SpanBuilderFactory(mock(SpanPostProcessor.class), SystemClockProvider.getInstance(), UUIDTraceIdProvider.getInstance(), Sampling.alwaysSampler());
@@ -330,5 +333,14 @@ public class SpanBuilderFactoryTest {
         final Span span = factory.createBuilderFrom(Span.getNoopInstance()).build();
 
         assertThat(span.isNoop()).isTrue();
+    }
+
+    @Test
+    public void GIVEN_aFactory_WHEN_closed_EXEPECT_factoryToDelegateToSpanPostProcessor() {
+        factory.close();
+
+        final SpanPostProcessor mock = factory.getProcessor();
+        verify(mock, times(1)).close();
+        verifyNoMoreInteractions(mock);
     }
 }

--- a/beeline-core/src/test/java/io/honeycomb/beeline/tracing/SpanPostProcessorTest.java
+++ b/beeline-core/src/test/java/io/honeycomb/beeline/tracing/SpanPostProcessorTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.setLenientDateParsing;
 import static org.mockito.Mockito.*;
 
 @SuppressWarnings("unchecked")
@@ -90,5 +91,13 @@ public class SpanPostProcessorTest {
         final Event event = spanPostProcessor.generateEvent(mockSpan);
 
         verify(event, never()).setDataset(any());
+    }
+
+    @Test
+    public void WHEN_closing_THEN_delegateToClient() {
+        spanPostProcessor.close();
+
+        verify(mockClient, times(1)).close();
+        verifyNoMoreInteractions(mockClient, mockSampler, mockEvent, mockSpan);
     }
 }

--- a/beeline-spring-boot-starter/pom.xml
+++ b/beeline-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.honeycomb.beeline</groupId>
         <artifactId>beeline-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
 
     <name>Beeline Java (Spring Boot Starter)</name>
@@ -16,7 +16,7 @@
     <description>Spring Boot Starter module to auto-configure Spring Boot with the Honeycomb Beeline for Java</description>
 
     <properties>
-        <beelineVersion>1.0.8</beelineVersion>
+        <beelineVersion>1.1.1</beelineVersion>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <name>Beeline Java (Parent)</name>
     <artifactId>beeline-parent</artifactId>
     <groupId>io.honeycomb.beeline</groupId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <packaging>pom</packaging>
 
     <description>Parent POM for the Honeycomb Beeline for Java</description>
@@ -70,7 +70,7 @@
         <jdkVersion>1.8</jdkVersion>
 
         <!-- COMPILE dependency versions  -->
-        <libhoneyVersion>1.1.1</libhoneyVersion>
+        <libhoneyVersion>1.1.2</libhoneyVersion>
         <springBootVersion>2.1.1.RELEASE</springBootVersion>
 
         <!-- TEST dependency versions  -->


### PR DESCRIPTION
Adding new BeelineBuilder with a simplified debug option to add DefaultDebugResponseObserver. BeelineBuilder can be used to easily construct a customized Beeline instance with support for advanced configuration options like adding proxies, etc.